### PR TITLE
feat(DCMAW): remove credential_identifier from credential request

### DIFF
--- a/openapi/cri.yaml
+++ b/openapi/cri.yaml
@@ -45,7 +45,6 @@ paths:
             schema:
               $ref: '#/components/schemas/CredentialRequestBody'
             example:
-              credential_identifier: 12345-2023
               proof:
                 proof_type: jwt
                 jwt: eyJraWQiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEva2V5cy8xIiwiYWxnIjoiRVMyNTYiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJzNkJoZFJrcXQzIiwiYXVkIjoiaHR0cHM6Ly9zZXJ2ZXIuZXhhbXBsZS5jb20iLCJpYXQiOjE1MzY5NTk5NTksIm5vbmNlIjoidFppZ25zbkZicCJ9.ewdkIkPV50iOeBUqMXCC_aZKPxgihac0aW9EkL1nOzM
@@ -233,12 +232,9 @@ components:
       type: object
       additionalProperties: false
       properties:
-        credential_identifier:
-          type: string
         proof:
           $ref: "#/components/schemas/Proof"
       required:
-        - credential_identifier
         - proof
     Proof:
       type: object


### PR DESCRIPTION
# _Remove Credential Identifier from CRI OpenAPI Spec_

The field `credential_identifier`  is not required in the `/credential` request body and therefore it has been removed.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Generate the documentation site locally ensuring it builds 
- [x] View on localhost ensuring the static website works
- [x] Pull request has a clear title with a short description about the update in the documentation
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before merging your pull request:
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
