### PR TITLE
Revert "Revert "chore: bump ruby/setup-ruby from 1.231.0 to 1.232.0""

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
+        uses: ruby/setup-ruby@fb404b9557c186e349162b0d8efb06e2bc36edea # v1.232.0
         with:
           bundler-cache: true
 


### PR DESCRIPTION
Reverts govuk-one-login/mobile-wallet-tech-docs#63

"Revert "chore: bump ruby/setup-ruby from 1.231.0 to 1.232.0" shouldn't have been raised. 

The original PR ("chore: bump ruby/setup-ruby from 1.231.0 to 1.232.0") is okay to be merged.