### PR TITLE
DCMAW-11982 & DCMAW-12671: fix links and change banner from Alpha to Beta

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -5,7 +5,7 @@ host:
 show_govuk_logo: true
 service_name: Wallet
 service_link: https://www.gov.uk/wallet
-phase: Alpha
+phase: Beta
 
 # Links to show on right-hand-side of header
 header_links:


### PR DESCRIPTION
## Proposed changes
### What changed
- Change the top banner 'GOV.UK Wallet' link from larry-the-cat.service to [www.gov.uk/wallet](https://www.gov.uk/wallet)
- Fix the repo links at the bottom to point to correct repo
- Change top banner from Alpha to Beta

### Why did it change
- Top-level banner is set to [www.gov.uk/wallet](https://www.gov.uk/wallet) for now, until a wallet.service.gov.uk page is written and available
- Repo links previously pointed to alphagov and were broken - they now go to govuk-one-login and work correctly
- Switching the banner was requested in [DCMAW-12671](https://govukverify.atlassian.net/browse/DCMAW-12671) - changes are in the same file as the links above so I combined these two requests

### Issue tracking
<!-- List any related Jira tickets -->

- [DCMAW-11982](https://govukverify.atlassian.net/browse/DCMAW-11982)
- [DCMAW-12671](https://govukverify.atlassian.net/browse/DCMAW-12671)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [ ] Update the `last_reviewed_on` field
- [ ] Generate the documentation site locally ensuring it builds
- [ ] View on localhost ensuring the static website works
- [ ] Commit messages that conform to conventional commit messages
- [ ] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-12671]: https://govukverify.atlassian.net/browse/DCMAW-12671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCMAW-11982]: https://govukverify.atlassian.net/browse/DCMAW-11982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCMAW-12671]: https://govukverify.atlassian.net/browse/DCMAW-12671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ