### PR TITLE
fix: add govuk_frontend.js

### DIFF
--- a/source/javascripts/govuk_frontend.js
+++ b/source/javascripts/govuk_frontend.js
@@ -1,0 +1,1 @@
+//= require govuk_frontend_all


### PR DESCRIPTION
## Proposed changes
### What changed
- Add a `govuk_frontend.js` file

### Why did it change
This is require when using `govuk_tech_docs` v4

### Issue tracking
<!-- List any related Jira tickets -->

- [DCMAW-13355](https://govukverify.atlassian.net/browse/DCMAW-13355)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [ ] Update the `last_reviewed_on` field
- [x] Generate the documentation site locally ensuring it builds
- [x] View on localhost ensuring the static website works
- [x] Commit messages that conform to conventional commit messages
- [x] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-13355]: https://govukverify.atlassian.net/browse/DCMAW-13355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ