### PR TITLE
Add govuk_frontend.js to fix 404 error

### DIFF
--- a/source/javascripts/govuk_frontend.js
+++ b/source/javascripts/govuk_frontend.js
@@ -1,0 +1,1 @@
+//= require govuk_frontend_all


### PR DESCRIPTION
## Proposed changes
### What changed
- Add `govuk_frontend.js` file

<img width="979" alt="image" src="https://github.com/user-attachments/assets/9adb7da4-fc9b-407b-a373-481e97b5362e" />


### Why did it change
This is required when using version 4 of `govuk_tech_docs` - see https://github.com/alphagov/tech-docs-gem/releases/tag/v4.0.0. Not having the file is currently causing a 404 error.

### Issue tracking
- [DCMAW-13355](https://govukverify.atlassian.net/browse/DCMAW-13355)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [ ] Update the `last_reviewed_on` field
- [x] Generate the documentation site locally ensuring it builds
- [x] View on localhost ensuring the static website works
- [x] Commit messages that conform to conventional commit messages
- [x] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-13355]: https://govukverify.atlassian.net/browse/DCMAW-13355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ