### PR TITLE
Set value of `key_attestations_required` to `{}`

### DIFF
--- a/openapi/cri.yaml
+++ b/openapi/cri.yaml
@@ -121,7 +121,7 @@ paths:
                       jwt:
                         proof_signing_alg_values_supported:
                           - ES256
-                        key_attestations_required:
+                        key_attestations_required: {}
                     display:
                       - name: Fishing Licence number
                         locale: en-GB

--- a/source/credential-issuer-functionality/metadata/api.html.md.erb
+++ b/source/credential-issuer-functionality/metadata/api.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: API
 weight: 100
-last_reviewed_on: 2025-03-21
+last_reviewed_on: 2025-06-09
 review_in: 6 months
 ---
 


### PR DESCRIPTION
## Proposed changes
### What changed
- Explicitly set the value of`key_attestations_required` to `{}`.

Tested locally.
<img width="1109" alt="Screenshot 2025-06-09 at 21 20 27" src="https://github.com/user-attachments/assets/b256b212-8aff-4408-ad8a-29a0253754b9" />

### Why did it change
- So that an empty object (`{}`) is rendered instead of `null`.

### Issue tracking
<!-- List any related Jira tickets -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [x] Update the `last_reviewed_on` field
- [x] Generate the documentation site locally ensuring it builds
- [x] View on localhost ensuring the static website works
- [x] Commit messages that conform to conventional commit messages
- [x] Pull request has a clear title with a short description about the update in the documentation
