### PR TITLE
DCMAW-13554 Update the @context value in the Did Document examples

### DIFF
--- a/openapi/cri.yaml
+++ b/openapi/cri.yaml
@@ -196,6 +196,7 @@ paths:
               example:
                 "@context":
                   - https://www.w3.org/ns/did/v1
+                  - https://w3id.org/security/suites/jws-2020/v1
                 id: did:web:example-credential-issuer.gov.uk
                 verificationMethod:
                   - id: did:web:example-credential-issuer.gov.uk#5dcbee863b5d7cc30c9ba1f7393dacc6c16610782e4b6a191f94a7e8b1e1510f

--- a/source/credential-issuer-functionality/did/index.html.md.erb
+++ b/source/credential-issuer-functionality/did/index.html.md.erb
@@ -54,7 +54,8 @@ Below is an example of a DID document containing an elliptic curve key based on 
 ```JSON
 {
    "@context":[
-      "https://www.w3.org/ns/did/v1"
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/suites/jws-2020/v1"
    ],
    "id":"did:web:example-credential-issuer.gov.uk",
    "verificationMethod":[


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

- Added the second value to `@context` property in DID Document examples to be "https://w3id.org/security/suites/jws-2020/v1"

<img width="1177" alt="Screenshot 2025-07-02 at 16 10 55" src="https://github.com/user-attachments/assets/cf35909a-2022-4287-98db-10270a153d77" />

<img width="1275" alt="Screenshot 2025-07-02 at 16 10 29" src="https://github.com/user-attachments/assets/6eaac0b3-0b09-4556-bb26-36f55e1da749" />


### Why did it change
<!-- Describe the reason these changes were made -->
The current DID document returned by the did:web API uses an incorrect value for the `@context` property. This needs to be updated to align with the [did:web method specification](https://w3c-ccg.github.io/did-method-web/).
### Issue tracking
<!-- List any related Jira tickets -->

- [DCMAW-13554](https://govukverify.atlassian.net/browse/DCMAW-13554)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [ ] Update the `last_reviewed_on` field
- [ ] Generate the documentation site locally ensuring it builds
- [ ] View on localhost ensuring the static website works
- [ ] Commit messages that conform to conventional commit messages
- [ ] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-13554]: https://govukverify.atlassian.net/browse/DCMAW-13554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ