### PR TITLE
DCMAW-15070 Adding more detail re. VC-JWT Photo Validation

### DIFF
--- a/source/credential-issuer-functionality/credential/index.html.md.erb
+++ b/source/credential-issuer-functionality/credential/index.html.md.erb
@@ -300,7 +300,7 @@ GOV.UK Wallet will validate the image to make sure that:
   * `FF D8 FF DB JPG`
   * `89 50 4E 47 0D 0A 1A 0A PNG`
   * `FF D8 FF E0 00 10 4A 46 49 46 00 01 JFIF`
-* The image but be 1 mebibyte (MiB) before encoding to Base64
+* The image must be 1 mebibyte (MiB) before encoding to Base64
 * The image must have EXIF metadata stripped
 
 If the GOV.UK Wallet fails to process an image in a credential, a `credential_failure` error will

--- a/source/credential-issuer-functionality/credential/index.html.md.erb
+++ b/source/credential-issuer-functionality/credential/index.html.md.erb
@@ -300,7 +300,7 @@ GOV.UK Wallet will validate the image to make sure that:
   * `FF D8 FF DB JPG`
   * `89 50 4E 47 0D 0A 1A 0A PNG`
   * `FF D8 FF E0 00 10 4A 46 49 46 00 01 JFIF`
-* The image must be 1 mebibyte (MiB) before encoding to Base64
+* The image must not exceed 1 MiB (1 Mebibyte = 1,048,576 bytes) in size before encoding to Base64
 * The image must have EXIF metadata stripped
 
 If the GOV.UK Wallet fails to process an image in a credential, a `credential_failure` error will

--- a/source/credential-issuer-functionality/credential/index.html.md.erb
+++ b/source/credential-issuer-functionality/credential/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Credential
 weight: 5
-last_reviewed_on: 2025-06-26
+last_reviewed_on: 2025-08-15
 review_in: 6 months
 ---
 

--- a/source/credential-issuer-functionality/credential/index.html.md.erb
+++ b/source/credential-issuer-functionality/credential/index.html.md.erb
@@ -290,7 +290,18 @@ Always consider the expiration of the underlying credential when setting JWT exp
 
 ##### Guidance on including photos
 
-If a photo is required in the credential, it must be included within the `credentialSubject` claim as a Base64-encoded string. The image must be in either JPEG or PNG format and must not exceed 1 MiB (1 Mebibyte = 1,048,576 bytes) in size before encoding to Base64.
+If a photo is required in the credential, it must be included within the `credentialSubject` claim as a Base64-encoded string.
+
+The GOV.UK Wallet will apply the following validation rules:
+
+* Format: JPEG, PNG, JFIF - as per the below specs:
+  * `FF D8 FF E0 JPG`
+  * `FF D8 FF EE JPG`
+  * `FF D8 FF DB JPG`
+  * `89 50 4E 47 0D 0A 1A 0A PNG`
+  * `FF D8 FF E0 00 10 4A 46 49 46 00 01 JFIF`
+* Size: hard technical limit of the encoded image → 1MB or 1,048,576 Bytes (base 2 / binary) before encoding to Base64.
+* The image must have EXIF metadata stripped
 
 Below are examples of claims representing PNG and JPEG images respectively, encoded in Base64 format:
 

--- a/source/credential-issuer-functionality/credential/index.html.md.erb
+++ b/source/credential-issuer-functionality/credential/index.html.md.erb
@@ -294,7 +294,7 @@ If a photo is required in the credential, you must include it within the `creden
 
 GOV.UK Wallet will validate the image to make sure that:
 
-* The image's format is JPG, PNG or JFIF conforming to one of the following specifications:
+* The image's format is JPG or PNG conforming to one of the following specifications:
   * `FF D8 FF E0 JPG`
   * `FF D8 FF EE JPG`
   * `FF D8 FF DB JPG`

--- a/source/credential-issuer-functionality/credential/index.html.md.erb
+++ b/source/credential-issuer-functionality/credential/index.html.md.erb
@@ -290,18 +290,21 @@ Always consider the expiration of the underlying credential when setting JWT exp
 
 ##### Guidance on including photos
 
-If a photo is required in the credential, it must be included within the `credentialSubject` claim as a Base64-encoded string.
+If a photo is required in the credential, you must include it within the `credentialSubject` claim as a Base64-encoded string.
 
-The GOV.UK Wallet will apply the following validation rules:
+GOV.UK Wallet will validate the image to make sure that:
 
-* Format: JPEG, PNG, JFIF - as per the below specs:
+* The image's format is JPG, PNG or JFIF conforming to one of the following specifications:
   * `FF D8 FF E0 JPG`
   * `FF D8 FF EE JPG`
   * `FF D8 FF DB JPG`
   * `89 50 4E 47 0D 0A 1A 0A PNG`
   * `FF D8 FF E0 00 10 4A 46 49 46 00 01 JFIF`
-* Size: hard technical limit of the encoded image → 1MB or 1,048,576 Bytes (base 2 / binary) before encoding to Base64.
+* The image but be 1 mebibyte (MiB) before encoding to Base64
 * The image must have EXIF metadata stripped
+
+If the GOV.UK Wallet fails to process an image in a credential, a `credential_failure` error will
+be returned, following the [notification specification](/credential-issuer-functionality/notification).
 
 Below are examples of claims representing PNG and JPEG images respectively, encoded in Base64 format:
 


### PR DESCRIPTION
## Proposed changes
### What changed
Added some more clarity about the validation logic the wallet runs as part of adding a photo for a VC-JWT.

### Why did it change
There was a little ambiguity in the validation for photos, which this PR hopes to fix

### Issue tracking

- [DCMAW-15070](https://govukverify.atlassian.net/browse/DCMAW-15070)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [x] Update the `last_reviewed_on` field
- [x] Generate the documentation site locally ensuring it builds
- [x] View on localhost ensuring the static website works
- [x] Commit messages that conform to conventional commit messages
- [x] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-15070]: https://govukverify.atlassian.net/browse/DCMAW-15070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ