### PR TITLE
chore: revert bump ruby from 3.3.6-bookworm to 3.4.5-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.4.5-bookworm
+FROM ruby:3.3.6-bookworm
 
 EXPOSE 4567:4567
 EXPOSE 35729:35729


### PR DESCRIPTION
Reverts govuk-one-login/mobile-wallet-tech-docs#118

The Docker image tag should match the exact Ruby version this application requires - that is, `3.3.6` as per the `.ruby-version` file.