### PR TITLE
chore: schedule dependency update checks weekly and group GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
     labels:
       - dependencies
     commit-message:
@@ -11,15 +13,23 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
     labels:
       - dependencies
     commit-message:
       prefix: chore
+    groups:
+      github-actions-updates:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
     labels:
       - dependencies
     commit-message:


### PR DESCRIPTION
## Proposed changes
### What changed
-  Update the `dependabot.yaml` configuration to schedule dependency update checks weekly on Mondays at 06:00 UTC.
- Group GitHub Actions updates.

### Why did it change
- To match other wallet repositories. 
- Reduce the number of pull requests by combining multiple updates into one.

### Issue tracking
<!-- List any related Jira tickets -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [ ] Update the `last_reviewed_on` field
- [ ] Generate the documentation site locally ensuring it builds
- [ ] View on localhost ensuring the static website works
- [x] Commit messages that conform to conventional commit messages
- [x] Pull request has a clear title with a short description about the update in the documentation
