### PR TITLE
feature: DCMAW-20076 - add config for tech-docs-monitor

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -47,5 +47,9 @@ show_contribution_banner: false
 github_repo: govuk-one-login/mobile-wallet-tech-docs
 github_branch: main
 
+# Ownership for page reviews
+default_owner_slack: '#di-mobile-wallet-tech-docs'
+owner_slack_workspace: gds
+
 # API description
 api_path: ./openapi/cri.yaml


### PR DESCRIPTION
## Proposed changes
### What changed
Adding the config needed for the tech-docs-monitor
Linked to this PR in the tech-docs-monitor repo: [https://github.com/alphagov/tech-docs-monitor/pull/86](https://github.com/alphagov/tech-docs-monitor/pull/86)

### Why did it change
So we get notified when pages expire

### Issue tracking

- [DCMAW-20076](https://govukverify.atlassian.net/browse/DCMAW-20076)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [ ] Update the `last_reviewed_on` field
- [ ] Generate the documentation site locally ensuring it builds
- [ ] View on localhost ensuring the static website works
- [x] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-20076]: https://govukverify.atlassian.net/browse/DCMAW-20076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ