### PR TITLE
feat: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,6 @@ repos:
         name: codespell
         description: Checks for common misspellings in text files.
         language: system
-        entry: bash -c 'cd example-credential-issuer && ./gradlew spotlessCheck -q'
+        entry: bash -c 'codespell'
         files: ^\.(erb|md)$
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [feat, fix, chore, docs, style, refactor, test, build, ci, perf, revert]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,13 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [feat, fix, chore, docs, style, refactor, test, build, ci, perf, revert]
+
+  - repo: local
+    hooks:
+      - id: codespell
+        name: codespell
+        description: Checks for common misspellings in text files.
+        language: system
+        entry: bash -c 'cd example-credential-issuer && ./gradlew spotlessCheck -q'
+        files: ^\.(erb|md)$
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,6 @@ repos:
         name: codespell
         description: Checks for common misspellings in text files.
         language: system
-        entry: bash -c 'codespell'
-        files: ^\.(erb|md)$
+        entry: codespell
+        files: '\.(erb|md)$'
         stages: [pre-commit]

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ pre-commit install
 pre-commit install --hook-type commit-msg
 ```
 
-## Contribut
+## Contribu
 
 This project uses [pre-commit](https://pre-commit.com/) to enforce code quality and validate commit messages against
 [Conventional Commits](https://github.com/conventional-changelog/commitlint) standards. Non-conforming messages will be rejected.

--- a/README.md
+++ b/README.md
@@ -149,3 +149,14 @@ The documentation is [© Crown copyright][copyright] and available under the ter
 [mit]: LICENCE.md
 [copyright]: http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/
 [ogl]: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
+
+## Pre-commit hooks
+
+```bash
+brew install pre-commit
+```
+
+```bash
+pre-commit install 
+pre-commit install --hook-type commit-msg
+```

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ pre-commit install
 pre-commit install --hook-type commit-msg
 ```
 
-## Conrtibute
+## Contribute
 
 This project uses [pre-commit](https://pre-commit.com/) to enforce code quality and validate commit messages against
 [Conventional Commits](https://github.com/conventional-changelog/commitlint) standards. Non-conforming messages will be rejected.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ pre-commit install
 pre-commit install --hook-type commit-msg
 ```
 
-## Contribu
+## Conrtibute
 
 This project uses [pre-commit](https://pre-commit.com/) to enforce code quality and validate commit messages against
 [Conventional Commits](https://github.com/conventional-changelog/commitlint) standards. Non-conforming messages will be rejected.

--- a/README.md
+++ b/README.md
@@ -160,3 +160,10 @@ brew install pre-commit
 pre-commit install 
 pre-commit install --hook-type commit-msg
 ```
+
+## Contribut
+
+This project uses [pre-commit](https://pre-commit.com/) to enforce code quality and validate commit messages against
+[Conventional Commits](https://github.com/conventional-changelog/commitlint) standards. Non-conforming messages will be rejected.
+
+Ensure your branch is up to date and all hooks pass before opening a pull request. Avoid using the git `--no-verify` flag to skip these checks unless absolutely necessary.


### PR DESCRIPTION
## Proposed changes
### What changed
Added pre-commit hooks.

### Why did it change
This project uses Pre-commit hooks to enforce code quality and validate commit messages against Conventional commits.

### Issue tracking
- [DCMAW-19407](https://govukverify.atlassian.net/browse/DCMAW-19407)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [ ] Update the `last_reviewed_on` field
- [ ] Generate the documentation site locally ensuring it builds
- [ ] View on localhost ensuring the static website works
- [ ] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-19407]: https://govukverify.atlassian.net/browse/DCMAW-19407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ