### PR TITLE
refactor: update the link for test harness

### DIFF
--- a/source/issue-credentials/use-sample-reference-material.html.md.erb
+++ b/source/issue-credentials/use-sample-reference-material.html.md.erb
@@ -12,7 +12,7 @@ You can use our test harness and sample reference data to help you issue credent
 
 ## Test harness
 
-You can use the [GOV.UK Wallet test harness](https://github.com/govuk-one-login/mobile-wallet-cri-test-harness) to validate your credential issuance implementation.
+You can use the [GOV.UK Wallet test harness](https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/tree/main/test-harness) to validate your credential issuance implementation.
 
 Follow the instructions in the README files to run the test scripts on your credential issuer.
 


### PR DESCRIPTION
## Proposed changes
### What changed
Updated the link for test harness.

### Why did it change
We moved Test Harness repo in `mobile-wallet-example-credential-issuer`.

### Issue tracking
- [DCMAW-19909](https://govukverify.atlassian.net/browse/DCMAW-19909)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [ ] Update the `last_reviewed_on` field
- [x] Generate the documentation site locally ensuring it builds
- [x] View on localhost ensuring the static website works
- [x] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-19909]: https://govukverify.atlassian.net/browse/DCMAW-19909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ