### PR TITLE
DCMAW-16580: Fix 200 response for Bitstring and Token status list API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,39 +91,39 @@ GEM
     fiber-local (1.1.0)
       fiber-storage
     fiber-storage (1.0.1)
-    google-protobuf (4.34.1)
+    google-protobuf (4.35.0)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.34.1-aarch64-linux-gnu)
+    google-protobuf (4.35.0-aarch64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.34.1-aarch64-linux-musl)
+    google-protobuf (4.35.0-aarch64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.34.1-arm64-darwin)
+    google-protobuf (4.35.0-arm64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.34.1-x86-linux-gnu)
+    google-protobuf (4.35.0-x86-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.34.1-x86-linux-musl)
+    google-protobuf (4.35.0-x86-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.34.1-x86_64-darwin)
+    google-protobuf (4.35.0-x86_64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.34.1-x86_64-linux-gnu)
+    google-protobuf (4.35.0-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.34.1-x86_64-linux-musl)
+    google-protobuf (4.35.0-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    govuk_tech_docs (6.2.1)
+    govuk_tech_docs (6.2.4)
       autoprefixer-rails
       chronic
       concurrent-ruby
       csv
-      haml (~> 6.0)
+      haml (>= 6, < 8)
       middleman
       middleman-autoprefixer
       middleman-compass
@@ -161,7 +161,7 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-event (1.14.5)
-    json (2.19.5)
+    json (2.19.7)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     listen (3.10.0)
@@ -285,24 +285,24 @@ GEM
     rouge (3.30.0)
     ruby-rc4 (0.1.5)
     sass (3.4.25)
-    sass-embedded (1.99.0)
+    sass-embedded (1.100.0)
       google-protobuf (~> 4.31)
       rake (>= 13)
-    sass-embedded (1.99.0-aarch64-linux-gnu)
+    sass-embedded (1.100.0-aarch64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-aarch64-linux-musl)
+    sass-embedded (1.100.0-aarch64-linux-musl)
       google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-arm-linux-gnueabihf)
+    sass-embedded (1.100.0-arm-linux-gnueabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-arm-linux-musleabihf)
+    sass-embedded (1.100.0-arm-linux-musleabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-arm64-darwin)
+    sass-embedded (1.100.0-arm64-darwin)
       google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-x86_64-darwin)
+    sass-embedded (1.100.0-x86_64-darwin)
       google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-x86_64-linux-gnu)
+    sass-embedded (1.100.0-x86_64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.99.0-x86_64-linux-musl)
+    sass-embedded (1.100.0-x86_64-linux-musl)
       google-protobuf (~> 4.31)
     sassc (2.4.0)
       ffi (~> 1.9)

--- a/openapi/cri.yaml
+++ b/openapi/cri.yaml
@@ -254,7 +254,7 @@ paths:
   # `crs`
   /t/{statusListIdentifier}:
     get:
-      description: A public endpoint that returns an IETF Token Status List JWT. The list that is returned depends on the list type for the GOV.UK Wallet credential issuer agreed at the time of registration. The response has a signed JWT in one of the two supported status list formats.
+      description: A public endpoint that returns an IETF Token Status List JWT. The list that is returned depends on the list type for the GOV.UK Wallet credential issuer agreed at the time of registration. The response has a signed JWT in one of the two supported status list formats. There is [more guidance and an example response](https://docs.wallet.service.gov.uk/issue-credentials/status-list/statuslist/#token-status-list-request-example).
       parameters:
         - in: path
           name: statusListIdentifier
@@ -267,9 +267,11 @@ paths:
         '200':
           description: "OK"
           content:
-            application/json:
+            application/statuslist+jwt:
               schema:
-                $ref: '#/components/schemas/TokenStatusListResponse'
+                type: string
+                description: Signed IETF Token Status List JWT containing the status list.
+              example: <JWT>
         '404':
           description: Not Found
           content:
@@ -291,7 +293,7 @@ paths:
   # `crs`
   /b/{statusListIdentifier}:
     get:
-      description: A public endpoint that returns a W3C Bitstring Status List credential JWT. The list that is returned depends on the list type for the GOV.UK Wallet credential issuer agreed at the time of registration. The response has a signed JWT in one of the two supported status list formats.
+      description: A public endpoint that returns a W3C Bitstring Status List JWT. The list that is returned depends on the list type for the GOV.UK Wallet credential issuer agreed at the time of registration. The response has a signed JWT in one of the two supported status list formats. There is [more guidance and an example response](https://docs.wallet.service.gov.uk/issue-credentials/status-list/statuslist/#bitstring-status-list-request-example).
       parameters:
         - in: path
           name: statusListIdentifier
@@ -306,7 +308,9 @@ paths:
           content:
             application/vc+jwt:
               schema:
-                $ref: '#/components/schemas/BitstringStatusListResponse'
+                type: string
+                description: Signed Bitstring Status List JWT containing the status list.
+              example: <JWT>
         '404':
           description: Not Found
           content:
@@ -829,194 +833,6 @@ components:
       type: string
       enum: ["b", "t"]
       example: "b"
-    TokenStatusListResponse:
-      type: string
-      description: JOSE signed IETF Token Status List JWT containing the status list.
-      example: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6ImU5YjE1OGI5Y2E2OWJlNDA2ODVjNjUyNTVkN2M3ODE2In0.eyJleHAiOjE3NTk5MTg3NTQsImlhdCI6MTc1OTMxMzk1NCwiaXNzIjoiaHR0cHM6Ly9jcnMuYWNjb3VudC5nb3YudWsvIiwic3RhdHVzX2xpc3QiOnsiYml0cyI6MiwibHN0IjoiZU5wemRBRUFBTWdBaGcifSwic3ViIjoiaHR0cHM6Ly9jcnMuYWNjb3VudC5nb3YudWsvdC8zQjBGM0JEMDg3QTciLCJ0dGwiOjM2MDB9.mESUJzZ07hCCdAzHXJZaxkKNdvYBJPwRLvqyP185t72hJUBMdFvVI-ynQjl7KRmcidxBXuI_gCHppAqctk1rAQ"
-      properties:
-        alg:
-          type: string
-          description: Algorithm used for signing the JWT (ES256) - Stored in JWT Header
-          example: "ES256"
-        typ:
-          type: string
-          description: Type of the token, should be "JWT" - Stored in JWT Header
-          example: "JWT"
-        kid:
-          type: string
-          description: |
-            Key ID used to identify the signing key in the status list JWKS endpoint.
-            The public key can be used to verify the signature of the JWT.
-          example: "ab2f3738-03ec-4312-a65e-7f0461a34e7b"
-        exp:
-          type: number
-          description: |
-            expiry date timestamp (as defined in RFC 7519) of the status list JWT.
-            The information in the JWT past date may be invalid and it must not be used beyond this date.
-            A stale status list may only be used in scenarios where there is an outage and the status list service is unable to serve a fresh status list.
-          example: "https://crs.account.gov.uk/"
-        iss:
-          type: string
-          description: url of the issuer of the status list.
-          example: "https://crs.account.gov.uk/"
-        iat:
-          type: number
-          description: (unix timestamp) Issued At date - As defined in RFC 7519
-          example: 1758038912
-        sub:
-          type: string
-          description: The URI of this status list that holds the status indexes.
-          example: "https://crs.account.gov.uk/"
-        ttl:
-          type: number
-          description: time duration in seconds for how long the status list can be cached.
-          example: "https://crs.account.gov.uk/b/A671FED3E9AD"
-        status_list:
-          type: object
-          description: |
-            The status list JWT containing the status information of the Referenced Token.
-            The status of each Referenced Token is identified using an index that maps to two bits within the byte array.
-            The byte array is compressed using DEFLATE [RFC 1951] with the ZLIB [RFC 1950] data format and base64url-encoded.
-          example:
-            status_list":
-              bits: 2,
-              lst: "eNpzdAEAAMgAhg"
-          properties:
-            bits:
-              type: number
-              minimum: 2
-              maximum: 2
-              description: |
-                Number of bits used to represent the status at a particular index. Only 2 bit status indexes are supported.
-            lst:
-              type: string
-              description: |
-                A compressed byte array containing the status information of the Referenced Token.
-                The status of each Referenced Token is identified using an index that maps to two bits within the byte array.
-                The byte array is compressed using DEFLATE [RFC 1951] with the ZLIB [RFC 1950] data format and base64url-encoded.
-      required:
-        - alg
-        - typ
-        - kid
-        - exp
-        - iss
-        - iat
-        - sub
-        - ttl
-        - status_list
-      xml:
-        name: issuerequest
-    BitstringStatusListResponse:
-      type: string
-      description: JOSE signed Bitstring status list credential containing the status list.
-      properties:
-        alg:
-          type: string
-          description: Algorithm used for signing the JWT (ES256) - Stored in JWT Header
-          example: "ES256"
-        kid:
-          type: string
-          description: |
-            Key ID used to identify the signing key in the status list JWKS endpoint.
-            The public key can be used to verify the signature of the JWT.
-          example: "ab2f3738-03ec-4312-a65e-7f0461a34e7b"
-        context:
-          type: array
-          description: Verifiable credential data model v2
-          example: ["https://www.w3.org/ns/credentials/v2", "https://www.w3.org/ns/credentials/examples/v2"]
-        id:
-          type: string
-          description: A unique URL that represents this status list.
-          example: "https://crs.account.gov.uk/b/A671FED3E9AD"
-        type:
-          type: array
-          description: The type of credential.
-          example: ["VerifiableCredential", "BitstringStatusListCredential"]
-        issuer:
-          type: string
-          description: The URL of the issuer of status list credential.
-          example: "https://crs.account.gov.uk/"
-        validFrom:
-          type: string
-          description: Date after which the status list credential is valid. ISO 8601 format YYYY-MM-DDTHH:MM:SSZ
-          example: "2025-10-01T14:00:00Z"
-        validUntil:
-          type: string
-          description: Date until the status list credential is valid. ISO 8601 format YYYY-MM-DDTHH:MM:SSZ
-          example: "2025-10-01T14:00:00Z"
-        expectedUpdate:
-          type: string
-          description: Date when GOV.UK Wallet will allow in-app refreshing. ISO 8601 format YYYY-MM-DDTHH:MM:00Z
-          example: "2025-09-01T14:00:00Z"
-        credentialSubject:
-          type: object
-          description: The status list subject about which the claims are made.
-          example:
-            credentialSubject:
-              id: "https://crs.account.gov.uk/b/A671FED3E9AD#list"
-              type: "BitstringStatusList"
-              statusSize: 2,
-              statusPurpose: "message"
-              statusMessage: [{"status": "0x0", "message": "VALID"}, {"status": "0x1", "message": "INVALID"}]
-              encodedList: "H4sIAAAAAAAAA3MUBABJTAvCAgAAAA"
-              ttl: 3600
-          properties:
-            id:
-              type: string
-              description: URL representing the unique id of the list.
-              example: "https://crs.account.gov.uk/b/A671FED3E9AD#list"
-            type:
-              type: string
-              description: This must only be BitstringStatusList
-              example: "BitstringStatusList"
-            statusSize:
-              type: number
-              description: The size of the status list in bits.
-              example: 2
-            statusPurpose:
-              type: string
-              description: The purpose of the status list as dexscribed in statusMessage.
-              example: "message"
-            statusMessage:
-              type: array
-              description: |
-                The status message representing different statuses supported by the list and appropriate hexadecimal value.
-                The statusMessage is an array of objects, each object containing a status and a message.
-                The status is a hexadecimal value representing the status of the Referenced Token.
-                The message is the status message representing different statuses supported by the list.
-              items:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    description: The hexadecimal string representig the status value in the status list.
-                    enum: ["0x0", "0x1"]
-                  message:
-                    type: string
-                    description: The status message representing different statuses supported by the list.
-                    enum: ["VALID", "INVALID"]
-                required:
-                  - status
-                  - message
-            encodedList:
-              type: string
-              description: |
-                The Multibase-encoded base64url (with no padding) [RFC 4648] representation of the GZIP-compressed [RFC 1952] bitstring values for the associated range of verifiable credential status values.
-              example: "H4sIAAAAAAAAA3MUBABJTAvCAgAAAA"
-            ttl:
-              type: number
-              description: The time to live of the status list when it is cached.
-              example: 3600
-      required:
-        - alg
-        - kid
-        - context
-        - id
-        - type
-        - issuer
-        - validFrom
-        - validUntil
-        - credentialSubject
     MetadataResponse:
       type: object
       properties:

--- a/openapi/cri.yaml
+++ b/openapi/cri.yaml
@@ -267,7 +267,7 @@ paths:
         '200':
           description: "OK"
           content:
-            application/statuslist+jwt:
+            application/json:
               schema:
                 $ref: '#/components/schemas/TokenStatusListResponse'
         '404':
@@ -302,7 +302,7 @@ paths:
           description: "Unique name representing the specific status list"
       responses:
         '200':
-          description: "OK"
+          description: OK
           content:
             application/vc+jwt:
               schema:


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
Edited cri.yaml file to make the 200 response visible for token status list API.

### Why did it change
<!-- Describe the reason these changes were made -->
So DVSs are aware how a successful request to check the status of a credential looks like.

### Issue tracking
<!-- List any related Jira tickets -->

- [DCMAW-16580](https://govukverify.atlassian.net/browse/DCMAW-16580)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [ ] Update the `last_reviewed_on` field
- [x] Generate the documentation site locally ensuring it builds
- [x] View on localhost ensuring the static website works
- [x] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-16580]: https://govukverify.atlassian.net/browse/DCMAW-16580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ