### PR TITLE
docs: bump review dates in flagged pages

### DIFF
--- a/source/contact-us.html.md.erb
+++ b/source/contact-us.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Contact us
 weight: 999
-last_reviewed_on: 2025-11-20
+last_reviewed_on: 2026-05-27
 review_in: 6 months
 layout: main
 ---

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,12 +1,12 @@
 ---
-title: GOV.UK Wallet Technical Documentation
+title: GOV.UK Wallet technical documentation
 weight: 1
-last_reviewed_on: 2025-11-27
+last_reviewed_on: 2026-05-27
 review_in: 6 months
 layout: main
 ---
 
-# GOV.UK Wallet Technical Documentation
+# GOV.UK Wallet technical documentation
 
 GOV.UK Wallet lets users save and share digital versions of their government documents on their smartphone or device.
 
@@ -15,7 +15,7 @@ If you work in a central government department, you can use GOV.UK Wallet to [is
 You will be able to [consume credentials from GOV.UK Wallet](#using-and-consuming-a-document) if you are a: 
 
 * public sector organisation (such as central government, the NHS, or a local authority) 
-* certified Digital Verification Services (DVS) provider on the [digital identity and attribute services register](https://www.digital-identity-services-register.service.gov.uk/)
+* certified Digital Verification Services (DVS) provider on the [register of digital identity and attribute services](https://www.digital-identity-services-register.service.gov.uk/)
 
 ## Issuing a document as a government service
 
@@ -33,7 +33,7 @@ This documentation is for people such as developers and product managers on serv
 You will be able to consume credentials from GOV.UK Wallet if you are: 
 
 * a public sector organisation (such as central government, the NHS, or a local authority) 
-* a certified Digital Verification Services (DVS) provider on the [digital identity and attribute services register](https://www.digital-identity-services-register.service.gov.uk/)
+* a certified Digital Verification Services (DVS) provider on the [register of digital identity and attribute services](https://www.digital-identity-services-register.service.gov.uk/)
 
 This documentation is for developers and service teams in public sector organisations or DVS providers. It can help you to:
 

--- a/source/issue-credentials/manage-keys/index.html.md.erb
+++ b/source/issue-credentials/manage-keys/index.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: Manage keys
 weight: 10
-last_reviewed_on: 2025-11-19
-review_in: 3 months
+last_reviewed_on: 2026-05-27
+review_in: 6 months
 layout: issuer
 ---
 

--- a/source/issue-credentials/use-sample-reference-material.html.md.erb
+++ b/source/issue-credentials/use-sample-reference-material.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Use sample reference material
 weight: 13
-last_reviewed_on: 2025-08-15
+last_reviewed_on: 2026-05-27
 review_in: 6 months
 layout: issuer
 ---


### PR DESCRIPTION
## Proposed changes
### What changed

Content review of non-technical pages (those that don't need an SME to check them, for example introductory pages, contact pages or pages signposting to other resources).
Bumping the review dates of reviewed non-technical pages.

### Why did it change

Daniel the Manual Spaniel is flagging that some pages are overdue for a review. Some of these pages don't contain technical content and so don't need SME review. This PR reviews those non-technical pages and bumps their review dates.
The technical pages that DTMS is flagging are currently being reviewed/updated by Doug Thomson and Dougal Rees in separate PRs.

### Issue tracking

N/A

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [x] Update the `last_reviewed_on` field
- [x] Generate the documentation site locally ensuring it builds
- [x] View on localhost ensuring the static website works
- [x] Pull request has a clear title with a short description about the update in the documentation
