### PR TITLE
docs: DCMAW-20684 - bump review dates and change review timeframe

### DIFF
--- a/source/issue-credentials/notification/api.html.md.erb
+++ b/source/issue-credentials/notification/api.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: API
 weight: 100
-last_reviewed_on: 2025-12-04
-review_in: 2 months
+last_reviewed_on: 2026-06-01
+review_in: 6 months
 layout: issuer
 ---
 

--- a/source/issue-credentials/notification/index.html.md.erb
+++ b/source/issue-credentials/notification/index.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: Handle notifications from GOV.UK Wallet
 weight: 9
-last_reviewed_on: 2025-12-01
-review_in: 3 months
+last_reviewed_on: 2026-06-01
+review_in: 6 months
 layout: issuer
 ---
 


### PR DESCRIPTION
## Proposed changes
### What changed
Bumping the review dates on the notification pages

### Why did it change
@dougal-rees-gds has reviewed the content and agreed there are no changes for now. This PR resets the review timer for those pages, and increases their review period from 2/3 months to 6 to match the rest of the tech docs.

### Issue tracking

- [DCMAW-20684](https://govukverify.atlassian.net/browse/DCMAW-20684)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [x] Update the `last_reviewed_on` field
- [x] Generate the documentation site locally ensuring it builds
- [x] View on localhost ensuring the static website works
- [x] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-20684]: https://govukverify.atlassian.net/browse/DCMAW-20684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ