### PR TITLE
docs: bump date and review period for accessibility statement

### DIFF
--- a/source/accessibility-statement.html.md.erb
+++ b/source/accessibility-statement.html.md.erb
@@ -2,8 +2,8 @@
 title: GOV.UK Wallet technical documentation accessibility statement
 weight: 999
 hide_in_navigation: true
-last_reviewed_on: 2025-12-04
-review_in: 6 months
+last_reviewed_on: 2026-06-10
+review_in: 1 year
 layout: main
 ---
 


### PR DESCRIPTION
## Proposed changes
### What changed

Bumped the review date and increased the review period for the accessibility statement

### Why did it change

Daniel the Manual Spaniel flagged it's out of date. I don't think it needs reviewing every 6 months so have increased the review period to a year.

### Issue tracking

N/A

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [x] Update the `last_reviewed_on` field
- [x] Generate the documentation site locally ensuring it builds
- [x] View on localhost ensuring the static website works
- [x] Pull request has a clear title with a short description about the update in the documentation
