### PR TITLE
DCMAW-20311: Specify credential_refresh_web_journey_url domain

### DIFF
--- a/openapi/cri.yaml
+++ b/openapi/cri.yaml
@@ -852,7 +852,7 @@ components:
             enum:
               - ES256
         credential_refresh_web_journey_url:
-          description: The URL where your users can go through the credential refresh web journey in their browser.
+          description: The URL where your users can go through the credential refresh web journey in their browser. This must be a gov.uk domain.
           type: string
         credential_validity_period_max_days:
           description: The credential’s validity period in days once it’s issued.

--- a/source/issue-credentials/metadata/index.html.md.erb
+++ b/source/issue-credentials/metadata/index.html.md.erb
@@ -53,7 +53,7 @@ Each credential object in `credential_configurations_supported` must include the
 | `doctype`                                 | The credential's document type identifier.                                                   |
 | `cryptographic_binding_methods_supported` | Set of methods available for cryptographically binding the issued credential.                 |
 | `credential_signing_alg_values_supported` | Set of algorithms that the credential issuer uses to sign the credential.                    |
-| `credential_refresh_web_journey_url`      | The URL where your users can go through the credential refresh web journey in their browser.  |
+| `credential_refresh_web_journey_url`      | The URL where your users can go through the credential refresh web journey in their browser. This must be a gov.uk domain.|
 | `credential_validity_period_max_days`     | The credential's validity period in days once it's issued.                                   |
 
 #### Credential expiry
@@ -63,7 +63,7 @@ Your credential issuer metadata endpoint response must include the following cus
 - `credential_refresh_web_journey_url`
 - `credential_validity_period_max_days`
 
-You must set `credential_refresh_web_journey_url` to the URL where your users can go through the credential refresh web journey in their browser. The `credential_validity_period_max_days` specifies the credential's validity period in days once it's issued. 
+You must set `credential_refresh_web_journey_url` to the URL where your users can go through the credential refresh web journey in their browser. This URL must be a gov.uk domain. The `credential_validity_period_max_days` specifies the credential's validity period in days once it's issued. 
 
 If the credential's `validUntil` date or `expiryDate` ends before your chosen validity period, the credential will expire earlier. For example, if you set `credential_validity_period_max_days` to 90 days but the credential's `expiryDate` will pass in 30 days' time, the credential will only be valid for 30 days.
 

--- a/source/issue-credentials/refresh-credentials/manual-refresh.html.md.erb
+++ b/source/issue-credentials/refresh-credentials/manual-refresh.html.md.erb
@@ -20,7 +20,7 @@ We recommend using manual credential refresh:
 
 ## Update credential issuer metadata
 
-For manual credential refresh to work, you must return [`credential_refresh_web_journey_url`](/issue-credentials/metadata/#credential-information) and `credential_validity_period_max_days` in your credential issuer metadata endpoint response. These are custom parameters that are not part of the OID4VCI specification.
+For manual credential refresh to work, you must return [`credential_refresh_web_journey_url`](/issue-credentials/metadata/#credential-information) and `credential_validity_period_max_days` in your credential issuer metadata endpoint response. These are custom parameters that are not part of the OID4VCI specification. Additionally, `credential_refresh_web_journey_url` must be a gov.uk domain to validate and issue your credentials properly.
 
 If you specify a `credential_refresh_web_journey_url`, GOV.UK Wallet will prompt your users when they need to refresh their valid credential. 
 

--- a/source/issue-credentials/refresh-credentials/manual-refresh.html.md.erb
+++ b/source/issue-credentials/refresh-credentials/manual-refresh.html.md.erb
@@ -20,7 +20,7 @@ We recommend using manual credential refresh:
 
 ## Update credential issuer metadata
 
-For manual credential refresh to work, you must return [`credential_refresh_web_journey_url`](/issue-credentials/metadata/#credential-information) and `credential_validity_period_max_days` in your credential issuer metadata endpoint response. These are custom parameters that are not part of the OID4VCI specification. Additionally, `credential_refresh_web_journey_url` must be a gov.uk domain to validate and issue your credentials properly.
+For manual credential refresh to work, you must return [`credential_refresh_web_journey_url`](/issue-credentials/metadata/#credential-information) and `credential_validity_period_max_days` in your credential issuer metadata endpoint response. These are custom parameters that are not part of the OID4VCI specification. `credential_refresh_web_journey_url` must be a gov.uk domain.
 
 If you specify a `credential_refresh_web_journey_url`, GOV.UK Wallet will prompt your users when they need to refresh their valid credential. 
 


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
Added information to clarify that credential_refresh_web_journey_url must be a gov.uk domain.

### Why did it change
<!-- Describe the reason these changes were made -->
To make sure issuers can pass the new validation and issue credentials correctly.

### Issue tracking
<!-- List any related Jira tickets -->

- [DCMAW-20311](https://govukverify.atlassian.net/browse/DCMAW-20311)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [ ] Update the `last_reviewed_on` field
- [x] Generate the documentation site locally ensuring it builds
- [x] View on localhost ensuring the static website works
- [x] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-20311]: https://govukverify.atlassian.net/browse/DCMAW-20311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ