### PR TITLE
REX-179: Removed empty lines from template.yaml

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -861,4 +861,3 @@ Outputs:
   #
   #Spoke VPC Outputs End Here
   #
-


### PR DESCRIPTION
## Proposed changes
### What changed
Removed empty line from template.yaml

### Why did it change
Previous commit is failing within GitHub Actions when deploying to AWS as the ECR image tag already exists. The previous commit was for template.yaml (CloudFormation). Attempting a fresh commit with a small change to template.yaml to see if that creates a new image tag and allows GitHub Action to run correctly.

### Issue tracking
<!-- List any related Jira tickets -->

- [REX-179](https://govukverify.atlassian.net/jira/software/c/projects/REX/boards/3614?selectedIssue=REX-179)


[REX-179]: https://govukverify.atlassian.net/browse/REX-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ