### PR TITLE
REX-179: Pointing DNS A record to SpokeALB

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -53,8 +53,8 @@ Resources:
       Type: A
       HostedZoneId: !ImportValue DocsWalletServicePublicHostedZoneId
       AliasTarget:
-        DNSName: !GetAtt ApplicationLoadBalancer.DNSName
-        HostedZoneId: !GetAtt ApplicationLoadBalancer.CanonicalHostedZoneID
+        DNSName: !GetAtt SpokeApplicationLoadBalancer.DNSName
+        HostedZoneId: !GetAtt SpokeApplicationLoadBalancer.CanonicalHostedZoneID
 
   DocsWalletServiceCertificate:
     Type: AWS::CertificateManager::Certificate


### PR DESCRIPTION
## Proposed changes
### What changed
Route53 (DNS) A record for docs.wallet.service.gov.uk changed from pointing at Application Load Balancer (ALB) to pointing at the Spoke Application Load Balancer.

Changes are on lines 56 and 57.

### Why did it change
To move traffic from "legacy" ALB to the Spoke ALB so that legacy VPC bound resources can in a future pull request be removed.

### Issue tracking
<!-- List any related Jira tickets -->

- [REX-179](https://govukverify.atlassian.net/jira/software/c/projects/REX/boards/3614?selectedIssue=REX-179)

[REX-179]: https://govukverify.atlassian.net/browse/REX-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ