### PR TITLE
DCMAW-21730: Rename the section titled 'Using and consuming a doc' on GOV.UK Wallet tech docs page

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -28,9 +28,9 @@ This documentation is for people such as developers and product managers on serv
 * [prepare your service to use GOV.UK Wallet](issue-credentials/before-integrating)
 * understand [how organisations and individuals can receive and validate digital credentials you have issued](verify-credentials/) when the holder presents them
 
-## Using and consuming a document 
+## Verifying and consuming a document 
 
-You will be able to consume credentials from GOV.UK Wallet if you are: 
+You will be able to verify and consume credentials from GOV.UK Wallet if you are: 
 
 * a public sector organisation (such as central government, the NHS, or a local authority) 
 * a certified Digital Verification Services (DVS) provider on the [register of digital identity and attribute services](https://www.digital-identity-services-register.service.gov.uk/)


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
Renamed the section titled 'Using and consuming a document' with 'Verifying and consuming a document' on the 'GOV.UK Wallet technical documentation' page.

### Why did it change
<!-- Describe the reason these changes were made -->
To align with naming conventions included in other Verifier GOV.UK Wallet tech doc pages.

### Issue tracking
<!-- List any related Jira tickets -->

- [DCMAW-21730](https://govukverify.atlassian.net/browse/DCMAW-21730)

### Changelog

If this change is significant (for example, launching a new feature or deprecating a feature), you should update the changelog found at `partials/_changelog.erb` under the heading 'Documentation updates'.

### Checklist
- [ ] Update the `last_reviewed_on` field
- [x] Generate the documentation site locally ensuring it builds
- [x] View on localhost ensuring the static website works
- [x] Pull request has a clear title with a short description about the update in the documentation


[DCMAW-21730]: https://govukverify.atlassian.net/browse/DCMAW-21730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ